### PR TITLE
feat:  add support for lazyframe + scan

### DIFF
--- a/src/polars_config_meta/__init__.py
+++ b/src/polars_config_meta/__init__.py
@@ -120,14 +120,15 @@ class ConfigMetaPlugin:
         pq.write_table(arrow_table, file_path, **kwargs)
 
 
-def read_parquet_with_meta(
-    file_path: str,
-    lazy: bool = False,
-    **kwargs,
-) -> pl.DataFrame:
+def _load_parquet_with_meta(
+    file_path: str, lazy: bool = False, **kwargs
+) -> pl.DataFrame | pl.LazyFrame:
     """
-    Read a Parquet file with PyArrow, extract the 'polars_plugin_meta' we stored,
-    load into a Polars DataFrame, and attach that metadata in our plugin.
+    Loads only the metadata from a parquet file with PyArrow
+    and extracts the 'polars_plugin_meta' we stored.
+    Then loads the data using either the polars
+    `.read_parquet' or `.scan_parquet` methods,
+    and attaches the associated plugin metadata.
     """
     import pyarrow.parquet as pq
 
@@ -149,3 +150,17 @@ def read_parquet_with_meta(
         df.config_meta.update(data_dict)
 
     return df
+
+
+def read_parquet_with_meta(file_path: str, **kwargs) -> pl.DataFrame:
+    """
+    Reads a parquet file along with the metadata.
+    """
+    return _load_parquet_with_meta(file_path, lazy=False, **kwargs)
+
+
+def scan_parquet_with_meta(file_path: str, **kwargs) -> pl.LazyFrame:
+    """
+    Scans a parquet file along with the metadata.
+    """
+    return _load_parquet_with_meta(file_path, lazy=True, **kwargs)

--- a/src/polars_config_meta/__init__.py
+++ b/src/polars_config_meta/__init__.py
@@ -121,7 +121,9 @@ class ConfigMetaPlugin:
 
 
 def read_parquet_with_meta(
-    file_path: str, lazy: bool = False, **kwargs
+    file_path: str,
+    lazy: bool = False,
+    **kwargs,
 ) -> pl.DataFrame:
     """
     Read a Parquet file with PyArrow, extract the 'polars_plugin_meta' we stored,

--- a/src/polars_config_meta/__init__.py
+++ b/src/polars_config_meta/__init__.py
@@ -121,7 +121,9 @@ class ConfigMetaPlugin:
 
 
 def _load_parquet_with_meta(
-    file_path: str, lazy: bool = False, **kwargs
+    file_path: str,
+    lazy: bool = False,
+    **kwargs,
 ) -> pl.DataFrame | pl.LazyFrame:
     """
     Loads only the metadata from a parquet file with PyArrow

--- a/src/polars_config_meta/__init__.py
+++ b/src/polars_config_meta/__init__.py
@@ -2,10 +2,11 @@ import json
 import weakref
 
 import polars as pl
-from polars.api import register_dataframe_namespace
+from polars.api import register_dataframe_namespace, register_lazyframe_namespace
 
 
 @register_dataframe_namespace("config_meta")
+@register_lazyframe_namespace("config_meta")
 class ConfigMetaPlugin:
     """
     A plugin that:
@@ -20,7 +21,7 @@ class ConfigMetaPlugin:
     _df_id_to_meta = {}
     _df_id_to_ref = {}
 
-    def __init__(self, df: pl.DataFrame):
+    def __init__(self, df: pl.DataFrame | pl.LazyFrame):
         self._df = df
         self._df_id = id(df)
         # If new to us, register a weakref so we can remove it on GC
@@ -46,7 +47,7 @@ class ConfigMetaPlugin:
     def update(self, mapping: dict) -> None:
         self._df_id_to_meta[self._df_id].update(mapping)
 
-    def merge(self, *dfs: pl.DataFrame) -> None:
+    def merge(self, *dfs: pl.DataFrame | pl.LazyFrame) -> None:
         """
         Merge metadata from other dataframes by dict.update.
         """
@@ -83,7 +84,7 @@ class ConfigMetaPlugin:
         def wrapper(*args, **kwargs):
             result = df_attr(*args, **kwargs)
             # If the result is a new DataFrame, copy the metadata
-            if isinstance(result, pl.DataFrame):
+            if isinstance(result, (pl.DataFrame, pl.LazyFrame)):
                 ConfigMetaPlugin(result)  # ensure plugin registration
                 self._df_id_to_meta[id(result)].update(self._df_id_to_meta[self._df_id])
             return result
@@ -106,7 +107,7 @@ class ConfigMetaPlugin:
         metadata_json = json.dumps(metadata_dict).encode("utf-8")
 
         # 2) convert DF to Arrow
-        arrow_table = self._df.to_arrow()
+        arrow_table = self._df.lazy().collect().to_arrow()
 
         # 3) attach custom metadata
         #    existing schema metadata + our custom "polars_plugin_meta"
@@ -119,24 +120,27 @@ class ConfigMetaPlugin:
         pq.write_table(arrow_table, file_path, **kwargs)
 
 
-def read_parquet_with_meta(file_path: str, **kwargs) -> pl.DataFrame:
+def read_parquet_with_meta(
+    file_path: str, lazy: bool = False, **kwargs
+) -> pl.DataFrame:
     """
     Read a Parquet file with PyArrow, extract the 'polars_plugin_meta' we stored,
     load into a Polars DataFrame, and attach that metadata in our plugin.
     """
     import pyarrow.parquet as pq
 
-    # 1) read with PyArrow
-    arrow_table = pq.read_table(file_path, **kwargs)
-
-    # 2) check for metadata
-    meta = arrow_table.schema.metadata or {}
+    # 1) read metadata with PyArrow
+    pyarrow_metadata = pq.read_schema(file_path).metadata
+    meta = pyarrow_metadata or {}
     custom_json = meta.get(b"polars_plugin_meta", None)
 
-    # 3) convert to Polars
-    df = pl.from_arrow(arrow_table)
+    # 2) read Parquet with Polars
+    if lazy:
+        df = pl.scan_parquet(file_path, **kwargs)
+    else:
+        df = pl.read_parquet(file_path, **kwargs)
 
-    # 4) if custom metadata found, parse it + store in plugin
+    # 3) if custom metadata found, parse it + store in plugin
     if custom_json is not None:
         data_dict = json.loads(custom_json.decode("utf-8"))
         ConfigMetaPlugin(df)  # ensure plugin registration

--- a/tests/metadata_core_test.py
+++ b/tests/metadata_core_test.py
@@ -2,7 +2,7 @@ import io
 
 import polars as pl
 
-from polars_config_meta import read_parquet_with_meta
+from polars_config_meta import read_parquet_with_meta, scan_parquet_with_meta
 
 
 def test_basic_metadata_storage():
@@ -131,7 +131,7 @@ def test_scan_parquet_with_metadata():
     df.config_meta.write_parquet(path)
 
     # Read back with scan_parquet
-    df_in = read_parquet_with_meta(path, lazy=True)
+    df_in = scan_parquet_with_meta(path)
     md_in = df_in.config_meta.get_metadata()
     assert md_in == meta_data, "Metadata lost or altered in scan"
 

--- a/tests/metadata_core_test.py
+++ b/tests/metadata_core_test.py
@@ -111,3 +111,45 @@ def test_parquet_roundtrip_in_memory():
         "author": "Carol",
         "purpose": "demo",
     }, "Metadata lost or altered in roundtrip"
+
+
+def test_scan_parquet_with_metadata():
+    """
+    Test reading Parquet file with metadata using scan_parquet.
+    """
+    df = pl.DataFrame({"col1": [1, 2], "col2": ["a", "b"]}).config_meta.lazy()
+
+    meta_data = {
+        "author": "David",
+        "purpose": "test",
+    }
+
+    df.config_meta.set(**meta_data)
+
+    # Write to a temporary file
+    path = "test.parquet"
+    df.config_meta.write_parquet(path)
+
+    # Read back with scan_parquet
+    df_in = read_parquet_with_meta(path, lazy=True)
+    md_in = df_in.config_meta.get_metadata()
+    assert md_in == meta_data, "Metadata lost or altered in scan"
+
+    # Add a new column
+    df_in = df_in.config_meta.with_columns(new_col=pl.col("col1") * 2)
+
+    md_in = df_in.config_meta.get_metadata()
+    assert md_in == meta_data, "Metadata lost or altered in scan"
+
+    # collect to dataframe and check that the same is correct
+    df_in = df_in.config_meta.collect()
+    assert df_in.shape == (2, 3), "Data shape changed on Parquet roundtrip"
+
+    # check that metadata persists after collect
+    md_in = df_in.config_meta.get_metadata()
+    assert md_in == meta_data, "Metadata lost or altered in scan"
+
+    # Clean up
+    import os
+
+    os.remove(path)


### PR DESCRIPTION
Adds support for lazyframe with `scan_parquet`, this way the benefit of polars optimizations while reading from parquet with filters/aggregations/etc can be kept. Only the metadata from the schema is read in with pyarrow.

Two questionable choices:
1. It uses the same function `read_parquet_with_meta` and just takes an additional flag to indicate whether it should scan or read. Alternatively having a `scan_parquet_with_meta` might be nicer
2. The `write_parquet` method handles lazyframes directly by collecting first. This is different from the polars method where a lazyframe does not have a `write_parquet` method, but saves the user having to write `df.meta_config.collect().meta_config.write_parquet(path)`